### PR TITLE
Document class relationships more explicitly

### DIFF
--- a/checkers/board.py
+++ b/checkers/board.py
@@ -34,8 +34,8 @@ class Board:
 	def get_possible_moves(self):
 		""" if there are availble capture moves for the current player, return list of capture moves, otherwise return list of possible positional moves """
 		capture_moves = self.get_possible_capture_moves()
-
-		return capture_moves if capture_moves else self.get_possible_positional_moves()
+		if capture_moves: return capture_moves
+		else: return self.get_possible_positional_moves()
 
 	def get_possible_capture_moves(self):
 		""" return list of possible capture moves for all of a player' pieces """

--- a/checkers/board.py
+++ b/checkers/board.py
@@ -5,13 +5,13 @@ from board_initializer import BoardInitializer
 
 class Board:
 	"""
-
+	board is contained by a GAME and referenced by PIECES
 	checkers board
-	has a list of pieces with their positions,
+	has a list of PIECES with their positions,
 	current player,
 	size of board.
 	gets list of possible moves, moves pieces, changes players after each turn
-	new board created for each move
+	new board created for each turn in a GAME
 
 	"""
 	def __init__(self):

--- a/checkers/game.py
+++ b/checkers/game.py
@@ -4,9 +4,9 @@ class Game:
 	"""
 
 	game of checkers object
-	a game has a series of boards, and a new board is created after each turn
+	a game has a BOARD, and a new BOARD is created to replace it after each turn
 	moves are kept track of in a list, and non-capture moves are limited so the game ends eventually
-	game calls methods to move pieces, checks limits, and determines winner and end of game
+	game calls methods to move PIECES, checks limits, and determines winner and end of game
 
 	"""
 	def __init__(self):

--- a/checkers/game.py
+++ b/checkers/game.py
@@ -29,7 +29,10 @@ class Game:
 
 		self.board = self.board.create_new_board_from_move(move)
 		self.moves.append(move)
-		self.moves_since_last_capture = 0 if self.board.previous_move_was_capture else self.moves_since_last_capture + 1
+		if self.board.previous_move_was_capture:
+			self.moves_since_last_capture = 0
+		else: 
+			self.moves_since_last_capture = self.moves_since_last_capture + 1
 
 		return self
 

--- a/checkers/piece.py
+++ b/checkers/piece.py
@@ -3,9 +3,10 @@ from argparse import ArgumentParser
 
 class Piece:
 	"""
+	pieces are kept in lists in BOARDS
 	individual checkers piece.  
-	each piece has an associated board, a position on that board, and a player  
-	pieces can find possible moves, move on the board, and capture enemy pieces
+	each piece has an associated BOARD, a position on that BOARD, and a player  
+	pieces can find possible moves, move on the BOARD, and capture enemy pieces
 
 	"""
 

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ Each position on the board is numbered 1 to 32. Each move is represented as an a
 
 Each piece movement is completely distinct, even if the move is part of a multiple capture series. In [Portable Draughts Notation](https://en.wikipedia.org/wiki/Portable_Draughts_Notation) mutli-capture series are usually represented by a `5-32` (for a particularly long series of jumps), but in certain situations there could be multiple pathways to achieve that final position. This game requires an explicit spelling out of each distinct move in the multi-capture series.
 
+In this library, a Game object represents an entire game of checkers, with a current Board and a list of moves.  A game limits the number of consecutive non-capture moves (40 by default) and checks for the end of game and the winner.  A game's board is updated each turn.  A Board object represents the state of the game at the current time.  Each board has several Pieces, size information, lists of possible moves and board positions, and the identity of the player for the current turn.  A Piece object represents an individual checkers piece.  A piece has a position, the identities of its player and the enemy player, an associated board, and indicators to show if it is kinged or captured.  Pieces can get lists of possible moves, move, and update its indicators.  
+
 # Usage
 
 Create a new game:


### PR DESCRIPTION
To improve understanding of the code, documentation in the readme.md file and in docstring comments has been updated to emphasize the relationships between classes, particularly those that are used directly by the end user: Game, Board, and Piece.  Docstring comments highlight relationships using all caps, and a paragraph is added to readme.

example:  
`board is contained by a game and referenced by pieces`  
is changed to 
`board is contained by a GAME and referenced by PIECES`